### PR TITLE
Potential fix for code scanning alert no. 1: Uncontrolled command line

### DIFF
--- a/Test_File.py
+++ b/Test_File.py
@@ -34,11 +34,20 @@ def login():
     else:
         return "Invalid credentials"
 
+ALLOWED_COMMANDS = {
+    "list": "ls",
+    "status": "status",
+    "uptime": "uptime"
+}
+
 @app.route('/run', methods=['POST'])
 def run():
     command = request.form.get('command')
-    result = subprocess.check_output(command, shell=True)
-    return result
+    if command in ALLOWED_COMMANDS:
+        result = subprocess.check_output(ALLOWED_COMMANDS[command], shell=True)
+        return result
+    else:
+        return "Invalid command", 400
 
 @app.route('/delete_user', methods=['POST'])
 def delete_user():


### PR DESCRIPTION
Potential fix for [https://github.com/charu12365/Code-Scanning-Test/security/code-scanning/1](https://github.com/charu12365/Code-Scanning-Test/security/code-scanning/1)

To fix the problem, we need to avoid passing user input directly to the `subprocess.check_output` function. Instead, we should use a predefined allowlist of acceptable commands and only execute those. This ensures that only safe, expected commands are run, and prevents arbitrary command execution.

1. Define a dictionary of allowed commands.
2. Check if the user-provided command is in the allowlist.
3. If the command is allowed, execute it; otherwise, return an error message.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
